### PR TITLE
Add error message when get token failed

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -50,6 +50,19 @@ fn get_token(search_config: &Arc<config::Config>,secrets: &mut Vec<String>) -> R
             Ok(result) => result.access_token().secret().to_string(),
             Err(err) => {
                 println!("get access token error: {}", err);
+                match err {
+                    oauth2::RequestTokenError::Request(_e) => {
+                        println!("response error: client does not exist or network error");
+                    },
+                    oauth2::RequestTokenError::ServerResponse(e) => {
+                        println!("server return error");
+                        println!("---");
+                        println!("{}", e.error());
+                        println!("{}", e.error_description().unwrap());
+                        println!("---");
+                    },
+                    _ => println!("some error"),
+                }
                 return Err(1);
             }
         };


### PR DESCRIPTION
When the access token acquisition fails, I don't know what caused it, so the detailed message returned by the server is displayed.
